### PR TITLE
remove tailing spaces and other improvements

### DIFF
--- a/chatlist.py
+++ b/chatlist.py
@@ -103,6 +103,7 @@ class XMPPBot(sleekxmpp.ClientXMPP):
                 return
             from_jid=msg['from'].bare
             body=msg['body']
+            body=body.rstrip()
             if not body:
                 return
             sys.stderr.write('%s:\t%s\n' % (from_jid, body))

--- a/chatlist.py
+++ b/chatlist.py
@@ -139,7 +139,10 @@ class XMPPBot(sleekxmpp.ClientXMPP):
             logging.warning('Exception: %s: %s\n' % (type(e).__name__, e))
 
     def dispatch_message(self, from_jid, body):
-        self.send_except(from_jid, '%s: %s' % (misc.getnick(self, from_jid), body))
+        if from_jid in config.omit_nickname_prefix:
+            self.send_except(from_jid, body)
+        else:
+            self.send_except(from_jid, '%s: %s' % (misc.getnick(self, from_jid), body))
 
     def send_except(self, except_jid, body):
         nowtime=time.time()

--- a/config.py.example
+++ b/config.py.example
@@ -19,6 +19,10 @@ welcome_message = 'Welcome to join this group!'
 group_nick = 'Test group'
 group_topic = 'Test group powered by chatlist'
 
+# do not include nicknames in messages from these JIDs
+# useful for bots and other automated global messages
+omit_nickname_prefix = ["ircbot@example.com"]
+
 # chat message logs
 logsize = 500 # Messages are temporarily stored in log so that you can use -old
 cmdlogsize = 500 # Commands are temporarily stored here.

--- a/msgfilters.py
+++ b/msgfilters.py
@@ -29,6 +29,12 @@ def filter_ayt(xmpp, msg):
         msg.reply(misc.replace_prefix(_('Please type /-ls to list online users, or type /-help for further help.'), config.command_prefix[0])).send()
     return True
 
-msg_filters=[filter_autoreply, filter_pastebin, filter_ayt]
+def filter_otr(xmpp, msg):
+    if msg['body'].startswith('?OTRv'):
+        msg.reply(_('Currently OTR is not supported. You should disable OTR for this buddy.')).send()
+        return False
+    return True
+
+msg_filters=[filter_autoreply, filter_pastebin, filter_ayt, filter_otr]
 
 # vim: et ft=python sts=4 sw=4 ts=4


### PR DESCRIPTION
```
Some XMPP clients (current AFAIK, Pidgin) generates
strange tailing spaces. I don't know exactly why it
happens, but it should be removed.

Signed-off-by: Tom Li <biergaizi@member.fsf.org>
```