### PR TITLE
ignore server message; handle SIGTERM

### DIFF
--- a/chatlist.py
+++ b/chatlist.py
@@ -103,6 +103,8 @@ class XMPPBot(sleekxmpp.ClientXMPP):
                 return
             if msg['type'] not in ('chat', 'normal'):
                 return
+            if not msg['from'].user:
+                return
             from_jid = msg['from'].bare
             body = msg['body']
             body = body.rstrip()

--- a/chatlist.py
+++ b/chatlist.py
@@ -7,6 +7,7 @@ import sleekxmpp
 import sys
 import time
 import logging
+import signal
 
 import command
 import config
@@ -163,6 +164,8 @@ class XMPPBot(sleekxmpp.ClientXMPP):
                         pass
 
 if __name__ == '__main__':
+    signal.signal(signal.SIGTERM, lambda signal, frame: sys.exit())  # handle SIGTERM, graceful exit
+
     misc.restarting = False
     misc.quiting = False
     misc.load_data()


### PR DESCRIPTION
> **chatlist.py: ignore message without an username**
> 
> Ignore all messages received without an username, this type of messages
> is often used in system notice and should be ignored. Especially, some
> servers with mandatory OTR requirement send an error if a non-OTR message
> is received, if we reply these automatic messages with an automatic response,
> an infinite loop could start and exhaust all system resources.

**Signed-off-by: Yifeng Li \<tomli@tomli.me\>**

> **chatlist.py: handle SIGTERM signal**
> 
> When using chatlist as a system daemon, a SIGTERM signal is used by
> the daemon manager to stop a daemon, but it's not handled in chatlist
> and causes chatlist to quit immediately without closing connection or
> saving data.
> 
> This commit adds a signal handler to call sys.exit() if SIGTERM is
> received, effectively converting a SIGTERM to a SystemExit exception.

**Signed-off-by: Yifeng Li \<tomli@tomli.me\>**